### PR TITLE
MethodDefinitionInterface::getReturnType() retuns null by default

### DIFF
--- a/src/MethodDefinition.php
+++ b/src/MethodDefinition.php
@@ -7,10 +7,9 @@ class MethodDefinition implements MethodDefinitionInterface, MutableListLineList
     const VISIBILITY_PUBLIC = 'public';
     const VISIBILITY_PROTECTED = 'protected';
     const VISIBILITY_PRIVATE = 'private';
-    const RETURN_TYPE_VOID = 'void';
 
     private $visibility = self::VISIBILITY_PUBLIC;
-    private $returnType = self::RETURN_TYPE_VOID;
+    private $returnType = null;
     private $name;
     private $lineList;
     private $arguments = [];
@@ -118,7 +117,7 @@ class MethodDefinition implements MethodDefinitionInterface, MutableListLineList
         return self::VISIBILITY_PRIVATE === $this->visibility;
     }
 
-    public function getReturnType(): string
+    public function getReturnType(): ?string
     {
         return $this->returnType;
     }

--- a/src/MethodDefinitionInterface.php
+++ b/src/MethodDefinitionInterface.php
@@ -9,5 +9,5 @@ interface MethodDefinitionInterface extends LineListInterface
     public function isPrivate(): bool;
     public function getName(): string;
     public function getArguments(): array;
-    public function getReturnType(): string;
+    public function getReturnType(): ?string;
 }

--- a/tests/Unit/MethodDefinitionTest.php
+++ b/tests/Unit/MethodDefinitionTest.php
@@ -30,7 +30,7 @@ class MethodDefinitionTest extends \PHPUnit\Framework\TestCase
         $methodDefinition = new MethodDefinition($name, $content, $arguments);
 
         $this->assertTrue($methodDefinition->isPublic());
-        $this->assertEquals(MethodDefinition::RETURN_TYPE_VOID, $methodDefinition->getReturnType());
+        $this->assertNull($methodDefinition->getReturnType());
         $this->assertSame($name, $methodDefinition->getName());
         $this->assertSame($content->getSources(), $methodDefinition->getSources());
         $this->assertEquals($expectedArguments, $methodDefinition->getArguments());
@@ -281,7 +281,7 @@ class MethodDefinitionTest extends \PHPUnit\Framework\TestCase
     public function testSetReturnType()
     {
         $methodDefinition = new MethodDefinition('name', new LineList());
-        $this->assertEquals(MethodDefinition::RETURN_TYPE_VOID, $methodDefinition->getReturnType());
+        $this->assertNull($methodDefinition->getReturnType());
 
         $returnType = 'array';
         $methodDefinition->setReturnType($returnType);


### PR DESCRIPTION
Fixes #106