### PR TITLE
LineList::fromContent() accepts whitespace at start of content

### DIFF
--- a/src/LineList.php
+++ b/src/LineList.php
@@ -117,7 +117,7 @@ class LineList implements LineListInterface, MutableListLineListInterface
         }
 
         if (strlen($lineString) > 2 && '//' === substr($lineString, 0, 2)) {
-            return new Comment(ltrim($lineString, '/'));
+            return new Comment(ltrim($lineString, '/ '));
         }
 
         return new Statement($lineString);

--- a/tests/Unit/LineListTest.php
+++ b/tests/Unit/LineListTest.php
@@ -797,6 +797,18 @@ class LineListTest extends \PHPUnit\Framework\TestCase
                 'content' => [],
                 'expectedLineList' => new LineList(),
             ],
+            'non-empty' => [
+                'content' => [
+                    '//comment without leading whitespace',
+                    '// comment with single leading whitespace',
+                    '//       comment with multiple leading whitespace',
+                ],
+                'expectedLineList' => new LineList([
+                    new Comment('comment without leading whitespace'),
+                    new Comment('comment with single leading whitespace'),
+                    new Comment('comment with multiple leading whitespace'),
+                ]),
+            ],
         ];
     }
 }


### PR DESCRIPTION
Fixes #118